### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+`@datama/icons` is a standalone SVG icon library that builds icons into JSON data, Vue 2 components, and an icon webfont. No backend, no database, no Docker needed.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm ci` |
+| Lint | `npx eslint .` |
+| Test | `npm test` |
+| Full build | `npm run build:all` |
+| Dev build (quick) | `npm run dev` |
+| Font build only | `npm run build:font` |
+
+### Notes
+
+- Node.js 18+ required (the VM has Node 22 which is compatible).
+- The `npm run build:all` pipeline runs: `build:svg` → `build:json` → `build:vue` → `build` (Rollup bundle) → `build:font` (webfont).
+- Tests (`npm test`) pass without running `build:all` first, but some checks emit warnings about missing dist files. For full coverage, run `npm run build:all` before `npm test`.
+- ESLint has pre-existing errors in the codebase (mostly in `test-icons.js` and `scripts/dev.js`). These are not blocking.
+- Build outputs go to `dist/` (JS bundles, Vue components, fonts). This directory is gitignored.
+- The `icons/` folder contains source SVGs organized by category (actions, data, illustrations, logos, navigation, settings, sort, sources, ui, vue3).
+- Icons in `icons/vue3/` are used specifically for webfont generation via `scripts/build-font.js`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development instructions for Cursor Cloud agents working on this repository.

## Changes

- Created `AGENTS.md` with:
  - Project overview (standalone SVG icon library)
  - Key commands table (install, lint, test, build, dev)
  - Non-obvious development notes (build pipeline order, pre-existing lint errors, output directory structure, icon categories)

## Testing

All development tasks verified:
- `npm ci` — dependencies install cleanly
- `npx eslint .` — linter runs (pre-existing errors in codebase, not blocking)
- `npm test` — 9/9 tests pass
- `npm run build:all` — full build pipeline succeeds (SVG → JSON → Vue → Rollup → Font)
- `npm run dev` — processes 118 icons successfully

[build_all_output.log](https://cursor.com/agents/bc-fd8b0e2d-4512-4b17-ace1-9b795301a390/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_all_output.log)
[test_output.log](https://cursor.com/agents/bc-fd8b0e2d-4512-4b17-ace1-9b795301a390/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd8b0e2d-4512-4b17-ace1-9b795301a390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd8b0e2d-4512-4b17-ace1-9b795301a390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

