### PR TITLE
feat(vue3): icône export (téléchargement) DEV-8532

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @datama/icons
 
-DataMa icon library with 118 icons, available as Vue 2 components and JSON data.
+DataMa icon library with 119 icons, available as Vue 2 components and JSON data.
 
 ## Installation
 
@@ -53,7 +53,7 @@ Vue.use(DatamaIcons);
 - `strokeWidth`: Number or string (default: 0)
 - `class`: String, object, or array for additional CSS classes
 
-## Available Icons (118)
+## Available Icons (119)
 
 | Nom de l'icône | Aperçu |
 |:-------------- |:------:|
@@ -90,6 +90,7 @@ Vue.use(DatamaIcons);
 | `excel-outline-2-svg` | <img src="icons/sources/excel-outline-2.svg" width="32" height="32" alt="excel-outline-2" /> |
 | `excel-outline-svg` | <img src="icons/sources/excel-outline.svg" width="32" height="32" alt="excel-outline" /> |
 | `excel-svg` | <img src="icons/sources/excel.svg" width="32" height="32" alt="excel" /> |
+| `export-svg` | <img src="icons/vue3/export.svg" width="32" height="32" alt="export" /> |
 | `eyes-svg` | <img src="icons/ui/eyes.svg" width="32" height="32" alt="eyes" /> |
 | `facebook-svg` | <img src="icons/sources/facebook.svg" width="32" height="32" alt="facebook" /> |
 | `flow-svg` | <img src="icons/ui/flow.svg" width="32" height="32" alt="flow" /> |

--- a/icons/vue3/export.svg
+++ b/icons/vue3/export.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M11,4 A1,1 0 0 1 12,3 A1,1 0 0 1 13,4 L13,10.2 L15.5,10.2 L12.25,14.85 Q12,15.15 11.75,14.85 L8.5,10.2 L11,10.2 L11,4 Z M5,17 L7,17 L7,19.5 L17,19.5 L17,17 L19,17 L19,21 L5,21 Z"/>
+</svg>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new Vue3 webfont icon `export` matching the Linear reference (downward arrow over a rounded U-shaped tray).

## Changes

- `icons/vue3/export.svg`: single `path` with `fill="currentColor"`, two closed regions (arrow + tray), rounded stem caps and a soft quadratic tip on the chevron for a stroke-like look compatible with `webfont`.
- `README.md`: preview row for `export-svg`.

## Verification

- `npm install` (local)
- `node scripts/build-font.js` succeeds; icon listed in output.
- `npm run build && npm test` passes.

Linear: DEV-8532
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DEV-8532](https://linear.app/datama/issue/DEV-8532/create-export-icon)

<div><a href="https://cursor.com/agents/bc-f51ff722-eae6-4a66-8d40-7a8449b9065d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f51ff722-eae6-4a66-8d40-7a8449b9065d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

