### PR TITLE
feat(ui): add download icon (DEV-8532)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Vue.use(DatamaIcons);
 | `disconnect-svg` | <img src="icons/vue3/disconnect.svg" width="32" height="32" alt="disconnect" /> |
 | `documentation-svg` | <img src="icons/ui/documentation.svg" width="32" height="32" alt="documentation" /> |
 | `documents-svg` | <img src="icons/ui/documents.svg" width="32" height="32" alt="documents" /> |
-| `download-svg` | <img src="icons/vue3/download.svg" width="32" height="32" alt="download" /> |
+| `download-svg` | <img src="icons/ui/download.svg" width="32" height="32" alt="download" /> |
 | `drop-down-1-svg` | <img src="icons/navigation/drop-down-1.svg" width="32" height="32" alt="drop-down-1" /> |
 | `drop-down-svg` | <img src="icons/navigation/drop-down.svg" width="32" height="32" alt="drop-down" /> |
 | `drop-left-svg` | <img src="icons/navigation/drop-left.svg" width="32" height="32" alt="drop-left" /> |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @datama/icons
 
-DataMa icon library with 118 icons, available as Vue 2 components and JSON data.
+DataMa icon library with 119 icons, available as Vue 2 components and JSON data.
 
 ## Installation
 
@@ -53,7 +53,7 @@ Vue.use(DatamaIcons);
 - `strokeWidth`: Number or string (default: 0)
 - `class`: String, object, or array for additional CSS classes
 
-## Available Icons (118)
+## Available Icons (119)
 
 | Nom de l'icône | Aperçu |
 |:-------------- |:------:|
@@ -80,6 +80,7 @@ Vue.use(DatamaIcons);
 | `disconnect-svg` | <img src="icons/vue3/disconnect.svg" width="32" height="32" alt="disconnect" /> |
 | `documentation-svg` | <img src="icons/ui/documentation.svg" width="32" height="32" alt="documentation" /> |
 | `documents-svg` | <img src="icons/ui/documents.svg" width="32" height="32" alt="documents" /> |
+| `download-svg` | <img src="icons/vue3/download.svg" width="32" height="32" alt="download" /> |
 | `drop-down-1-svg` | <img src="icons/navigation/drop-down-1.svg" width="32" height="32" alt="drop-down-1" /> |
 | `drop-down-svg` | <img src="icons/navigation/drop-down.svg" width="32" height="32" alt="drop-down" /> |
 | `drop-left-svg` | <img src="icons/navigation/drop-left.svg" width="32" height="32" alt="drop-left" /> |

--- a/icons/ui/download.svg
+++ b/icons/ui/download.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M12,4 L12,11 M8.5,10 L12,14 L15.5,10 M5,17 L5,21 L19,21 L19,17"/>
+  <path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M12,4 L12,14 L8.5,10 M12,14 L15.5,10 M5,17 L5,21 L19,21 L19,17"/>
 </svg>

--- a/icons/ui/download.svg
+++ b/icons/ui/download.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M12,4 L12,11 M8.5,10 L12,14 L15.5,10 M5,17 L5,21 L19,21 L19,17"/>
+</svg>

--- a/icons/vue3/download.svg
+++ b/icons/vue3/download.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M11,4 A1,1 0 0 1 12,3 A1,1 0 0 1 13,4 L13,10.2 L15.5,10.2 L12.25,14.85 Q12,15.15 11.75,14.85 L8.5,10.2 L11,10.2 L11,4 Z M5,17 L7,17 L7,19.5 L17,19.5 L17,17 L19,17 L19,21 L5,21 Z"/>
+</svg>

--- a/icons/vue3/download.svg
+++ b/icons/vue3/download.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <path fill="currentColor" d="M11,4 A1,1 0 0 1 12,3 A1,1 0 0 1 13,4 L13,10.2 L15.5,10.2 L12.25,14.85 Q12,15.15 11.75,14.85 L8.5,10.2 L11,10.2 L11,4 Z M5,17 L7,17 L7,19.5 L17,19.5 L17,17 L19,17 L19,21 L5,21 Z"/>
-</svg>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **download** icon for DEV-8532 in `icons/ui/`, matching the reference design with consistent 2px stroke line art.

## Design

- **Arrow**: vertical stem + open chevron tip (two straight lines, not a filled triangle)
- **Tray**: U-shaped base drawn as a single stroke path so side and bottom bars share the same `stroke-width="2"`
- Stroke properties per project rules: `currentColor`, `stroke-linecap="round"`, `stroke-linejoin="round"`

## Changes

- Add `icons/ui/download.svg`
- Update `README.md` (`download-svg` preview)
- Remove `icons/vue3/download.svg` (icon belongs in UI set, not webfont set)

## Verification

- `npm run build` — 119 icons, includes `download-svg`
- `npm test` — all tests pass

Closes DEV-8532
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DEV-8532](https://linear.app/datama/issue/DEV-8532/create-export-icon)

<div><a href="https://cursor.com/agents/bc-c380c439-72c8-4605-bc3a-602b8a4ac285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c380c439-72c8-4605-bc3a-602b8a4ac285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

